### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ StatusBarCompat.compat(this, 0xFFFF0000);
 
 ## 效果图
 
-###默认效果
+### 默认效果
 
 * 4.4
 
@@ -35,7 +35,7 @@ StatusBarCompat.compat(this, 0xFFFF0000);
 
 
 
-###指定颜色
+### 指定颜色
 
 
 * 4.4


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
